### PR TITLE
Include jsoup  to the project as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PinCrawl/lib/jsoup"]
+	path = PinCrawl/lib/jsoup
+	url = git@github.com:jhy/jsoup.git

--- a/.idea/artifacts/PinCrawl_jar.xml
+++ b/.idea/artifacts/PinCrawl_jar.xml
@@ -3,7 +3,6 @@
     <output-path>$PROJECT_DIR$/out/artifacts/PinCrawl_jar</output-path>
     <root id="archive" name="PinCrawl.jar">
       <element id="module-output" name="PinCrawl" />
-      <element id="extracted-dir" path="$PROJECT_DIR$/../jsoup-1.8.2.jar" path-in-jar="/" />
     </root>
   </artifact>
 </component>

--- a/PinCrawl/.classpath
+++ b/PinCrawl/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-	<classpathentry kind="lib" path="C:/Users/kpauly2/Downloads/jsoup-1.8.2.jar"/>
+	<classpathentry kind="lib" path="lib/jsoup/src/main/java"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/PinCrawl/PinCrawl.iml
+++ b/PinCrawl/PinCrawl.iml
@@ -4,6 +4,7 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/lib/jsoup/src/main/java" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/PinCrawl/PinCrawl.iml
+++ b/PinCrawl/PinCrawl.iml
@@ -8,14 +8,5 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/../../jsoup-1.8.2.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
   </component>
 </module>


### PR DESCRIPTION
When I cloned this repository, I can't compile app, because I must download jsoup first, and include it to the project as external lib. (And remove yours `C:/Users/kpauly2/Downloads/jsoup-1.8.2.jar`)
Therefore I suggest include this dependency to the project as git-submodule, from official Jsoup repository https://github.com/jhy/jsoup
